### PR TITLE
[BUGFIX] Prevent duplicated tag creation

### DIFF
--- a/Classes/Synchronization/Synchronizer.php
+++ b/Classes/Synchronization/Synchronizer.php
@@ -183,9 +183,14 @@ class Synchronizer
     protected function addTags(Asset $asset)
     {
         foreach ($this->source->getAssetTags() as $tagLabel) {
-            $tag = new Tag($tagLabel);
-            if (!$asset->getTags()->contains($tag)) {
+            $tag = $this->tagRepository->findOneByLabel($tagLabel);
+
+            if ($tag === null) {
+                $tag = new Tag($tagLabel);
                 $this->tagRepository->add($tag);
+            }
+
+            if (!$asset->getTags()->contains($tag)) {
                 $asset->addTag($tag);
             }
         }


### PR DESCRIPTION
Prevents the synchronizer from creating
duplicated tags with the same label.
Applying the existing tag to the asset instead.